### PR TITLE
Refactor implementation of ParseUlimit function

### DIFF
--- a/ulimit.go
+++ b/ulimit.go
@@ -73,25 +73,34 @@ func ParseUlimit(val string) (*Ulimit, error) {
 		return nil, fmt.Errorf("invalid ulimit type: %s", parts[0])
 	}
 
-	limitVals := strings.SplitN(parts[1], ":", 2)
-	if len(limitVals) > 2 {
+	var (
+		soft int64
+		hard = &soft // default to soft in case no hard was set
+		temp int64
+		err  error
+	)
+	switch limitVals := strings.Split(parts[1], ":"); len(limitVals) {
+	case 2:
+		temp, err = strconv.ParseInt(limitVals[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		hard = &temp
+		fallthrough
+	case 1:
+		soft, err = strconv.ParseInt(limitVals[0], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	default:
 		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
 	}
 
-	soft, err := strconv.ParseInt(limitVals[0], 10, 64)
-	if err != nil {
-		return nil, err
+	if soft > *hard {
+		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
 	}
 
-	hard := soft // in case no hard was set
-	if len(limitVals) == 2 {
-		hard, err = strconv.ParseInt(limitVals[1], 10, 64)
-	}
-	if soft > hard {
-		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, hard)
-	}
-
-	return &Ulimit{Name: parts[0], Soft: soft, Hard: hard}, nil
+	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil
 }
 
 // GetRlimit returns the RLimit corresponding to Ulimit.

--- a/ulimit_test.go
+++ b/ulimit_test.go
@@ -58,6 +58,12 @@ func TestParseUlimitInvalidValueType(t *testing.T) {
 	} else if _, ok := err.(*strconv.NumError); !ok {
 		t.Fatalf("expected error on bad value type, but got `%s`", err)
 	}
+
+	if _, err := ParseUlimit("nofile=1024:asdf"); err == nil {
+		t.Fatal("expected error on bad value type, but got no error")
+	} else if _, ok := err.(*strconv.NumError); !ok {
+		t.Fatalf("expected error on bad value type, but got `%s`", err)
+	}
 }
 
 func TestUlimitStringOutput(t *testing.T) {

--- a/ulimit_test.go
+++ b/ulimit_test.go
@@ -2,6 +2,7 @@ package units
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -53,7 +54,9 @@ func TestParseUlimitHardLessThanSoft(t *testing.T) {
 
 func TestParseUlimitInvalidValueType(t *testing.T) {
 	if _, err := ParseUlimit("nofile=asdf"); err == nil {
-		t.Fatal("expected error on bad value type")
+		t.Fatal("expected error on bad value type, but got no error")
+	} else if _, ok := err.(*strconv.NumError); !ok {
+		t.Fatalf("expected error on bad value type, but got `%s`", err)
 	}
 }
 

--- a/ulimit_test.go
+++ b/ulimit_test.go
@@ -46,13 +46,13 @@ func TestParseUlimitBadFormat(t *testing.T) {
 }
 
 func TestParseUlimitHardLessThanSoft(t *testing.T) {
-	if _, err := ParseUlimit("nofile:1024:1"); err == nil {
+	if _, err := ParseUlimit("nofile=1024:1"); err == nil {
 		t.Fatal("expected error on hard limit less than soft limit")
 	}
 }
 
 func TestParseUlimitInvalidValueType(t *testing.T) {
-	if _, err := ParseUlimit("nofile:asdf"); err == nil {
+	if _, err := ParseUlimit("nofile=asdf"); err == nil {
 		t.Fatal("expected error on bad value type")
 	}
 }


### PR DESCRIPTION
Two problems exist in old code:
- The condition in statement `if len(limitVals) > 2` never evaluates to
  true, because of `strings.SplitN(s, sep string, n int)` will return at
  most n substrings when n > 0.
- Error `err` is ignored in parsing hard limitation value. Thus we may
  get inaccurate error message when invalid hard limitation value
  encountered.

Signed-off-by: Kezhu Wang <kezhuw@gmail.com>