### PR TITLE
Fix typo

### DIFF
--- a/size.go
+++ b/size.go
@@ -34,7 +34,7 @@ var (
 	sizeRegex  = regexp.MustCompile(`^(\d+)([kKmMgGtTpP])?[bB]?$`)
 )
 
-var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+var decimapAbbrs = []string{"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 
 // CustomSize returns a human-readable approximation of a size

--- a/size_test.go
+++ b/size_test.go
@@ -70,8 +70,8 @@ func TestBytesSize(t *testing.T) {
 }
 
 func TestHumanSize(t *testing.T) {
-	assertEquals(t, "1 kB", HumanSize(1000))
-	assertEquals(t, "1.024 kB", HumanSize(1024))
+	assertEquals(t, "1 KB", HumanSize(1000))
+	assertEquals(t, "1.024 KB", HumanSize(1024))
 	assertEquals(t, "1 MB", HumanSize(1000000))
 	assertEquals(t, "1.049 MB", HumanSize(1048576))
 	assertEquals(t, "2 MB", HumanSize(2*MB))


### PR DESCRIPTION
Replace "kB" with "KB"

I might be wrong, `docker stats` shows `kB` but man docs says `KB`, so I guess this is a typo.

@calavera Feel free to close this if you're doing it on purpose. :smile: 

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>