### PR TITLE
Enhance FromHumanSize to parse float64 string

### DIFF
--- a/size.go
+++ b/size.go
@@ -31,7 +31,7 @@ type unitMap map[string]int64
 var (
 	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
 	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
-	sizeRegex  = regexp.MustCompile(`^(\d+)([kKmMgGtTpP])?[bB]?$`)
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
 )
 
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
@@ -77,19 +77,19 @@ func RAMInBytes(size string) (int64, error) {
 // Parses the human-readable size string into the amount it represents.
 func parseSize(sizeStr string, uMap unitMap) (int64, error) {
 	matches := sizeRegex.FindStringSubmatch(sizeStr)
-	if len(matches) != 3 {
+	if len(matches) != 4 {
 		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
 	}
 
-	size, err := strconv.ParseInt(matches[1], 10, 0)
+	size, err := strconv.ParseFloat(matches[1], 64)
 	if err != nil {
 		return -1, err
 	}
 
-	unitPrefix := strings.ToLower(matches[2])
+	unitPrefix := strings.ToLower(matches[3])
 	if mul, ok := uMap[unitPrefix]; ok {
-		size *= mul
+		size *= float64(mul)
 	}
 
-	return size, nil
+	return int64(size), nil
 }

--- a/size_test.go
+++ b/size_test.go
@@ -93,13 +93,15 @@ func TestFromHumanSize(t *testing.T) {
 	assertSuccessEquals(t, 32*TB, FromHumanSize, "32Tb")
 	assertSuccessEquals(t, 32*PB, FromHumanSize, "32Pb")
 
+	assertSuccessEquals(t, 32.5*KB, FromHumanSize, "32.5kB")
+	assertSuccessEquals(t, 32.5*KB, FromHumanSize, "32.5 kB")
+	assertSuccessEquals(t, 32, FromHumanSize, "32.5 B")
+
 	assertError(t, FromHumanSize, "")
 	assertError(t, FromHumanSize, "hello")
 	assertError(t, FromHumanSize, "-32")
-	assertError(t, FromHumanSize, "32.3")
+	assertError(t, FromHumanSize, ".3kB")
 	assertError(t, FromHumanSize, " 32 ")
-	assertError(t, FromHumanSize, "32.3Kb")
-	assertError(t, FromHumanSize, "32 mb")
 	assertError(t, FromHumanSize, "32m b")
 	assertError(t, FromHumanSize, "32bm")
 }
@@ -119,13 +121,14 @@ func TestRAMInBytes(t *testing.T) {
 	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32PB")
 	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32P")
 
+	assertSuccessEquals(t, 32, RAMInBytes, "32.3")
+	tmp := 32.3 * MiB
+	assertSuccessEquals(t, int64(tmp), RAMInBytes, "32.3 mb")
+
 	assertError(t, RAMInBytes, "")
 	assertError(t, RAMInBytes, "hello")
 	assertError(t, RAMInBytes, "-32")
-	assertError(t, RAMInBytes, "32.3")
 	assertError(t, RAMInBytes, " 32 ")
-	assertError(t, RAMInBytes, "32.3Kb")
-	assertError(t, RAMInBytes, "32 mb")
 	assertError(t, RAMInBytes, "32m b")
 	assertError(t, RAMInBytes, "32bm")
 }


### PR DESCRIPTION
Currently FromHumanSize can only interpret format of '32kB', this commit
enhance it to interpret float64 string with blank such as '32.3 kB'.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

I need this function for doing `docker stats` integration test, because `docker stats` use `HumanSize` to  format byte into human readable string, now I need to revert the string to byte number. But `FromHumanSize` can't interpret `23.3 kB`, so this commit add float64 support.

I also add the blank support but it doesn't matter if you don't like it.

I think you may have special considerations for only supporting int64, but I'm not sure what's it. 
I can make relevant change based on your ideas. 
Ping @calavera 