### PR TITLE
Make human-readable size precision 1 digit and aligned as possible

### DIFF
--- a/size.go
+++ b/size.go
@@ -90,18 +90,20 @@ func parseSize(sizeStr string, uMap unitMap) (int64, error) {
 	return int64(size), nil
 }
 
-// Returns a custom human-readable size according to given base and units
-func customBaseSize(size, base float64, units []string) string {
-	newSize, _ := calMagnitudeAndUnits(size, base, units)
+// Returns a custom human-readable size according to given base and units.
+func customBaseSize(size, base float64, _units []string) string {
+	newSize, units := calMagnitudeAndUnits(size, base, _units)
 	fmtStr := "%3.1e %s"
 	if newSize <= 9999.0 {
 		fmtStr = "%3.1f %s"
 	}
-	return CustomSize(fmtStr, size, base, units)
+	// passing newSize+1 as base and []string{units} as _map
+	// to skip the for loop in calMagnitudeAndUnits called in CustomSize.
+	return CustomSize(fmtStr, newSize, newSize+1, []string{units})
 }
 
 // Calculates and returns the size's magnitude and units
-// as given by base and units
+// as given by base and units.
 func calMagnitudeAndUnits(size, base float64, units []string) (float64, string) {
 	i := 0
 	unitsLimit := len(units) - 1

--- a/size.go
+++ b/size.go
@@ -40,25 +40,20 @@ var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB",
 // CustomSize returns a human-readable approximation of a size
 // using custom format.
 func CustomSize(format string, size float64, base float64, _map []string) string {
-	i := 0
-	unitsLimit := len(_map) - 1
-	for size >= base && i < unitsLimit {
-		size = size / base
-		i++
-	}
-	return fmt.Sprintf(format, size, _map[i])
+	newSize, units := calMagnitudeAndUnits(size, base, _map)
+	return fmt.Sprintf(format, newSize, units)
 }
 
 // HumanSize returns a human-readable approximation of a size
 // capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
 func HumanSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
+	return customBaseSize(size, 1000.0, decimapAbbrs)
 }
 
 // BytesSize returns a human-readable size in bytes, kibibytes,
 // mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
 func BytesSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1024.0, binaryAbbrs)
+	return customBaseSize(size, 1024.0, binaryAbbrs)
 }
 
 // FromHumanSize returns an integer from a human-readable specification of a
@@ -93,4 +88,26 @@ func parseSize(sizeStr string, uMap unitMap) (int64, error) {
 	}
 
 	return int64(size), nil
+}
+
+// Returns a custom human-readable size according to given base and units
+func customBaseSize(size, base float64, units []string) string {
+	newSize, _ := calMagnitudeAndUnits(size, base, units)
+	fmtStr := "%3.1e %s"
+	if newSize <= 9999.0 {
+		fmtStr = "%3.1f %s"
+	}
+	return CustomSize(fmtStr, size, base, units)
+}
+
+// Calculates and returns the size's magnitude and units
+// as given by base and units
+func calMagnitudeAndUnits(size, base float64, units []string) (float64, string) {
+	i := 0
+	unitsLimit := len(units) - 1
+	for size >= base && i < unitsLimit {
+		size = size / base
+		i++
+	}
+	return size, units[i]
 }

--- a/size_test.go
+++ b/size_test.go
@@ -60,26 +60,26 @@ func ExampleRAMInBytes() {
 }
 
 func TestBytesSize(t *testing.T) {
-	assertEquals(t, "1 KiB", BytesSize(1024))
-	assertEquals(t, "1 MiB", BytesSize(1024*1024))
-	assertEquals(t, "1 MiB", BytesSize(1048576))
-	assertEquals(t, "2 MiB", BytesSize(2*MiB))
-	assertEquals(t, "3.42 GiB", BytesSize(3.42*GiB))
-	assertEquals(t, "5.372 TiB", BytesSize(5.372*TiB))
-	assertEquals(t, "2.22 PiB", BytesSize(2.22*PiB))
-	assertEquals(t, "1.049e+06 YiB", BytesSize(KiB*KiB*KiB*KiB*KiB*PiB))
+	assertEquals(t, "1.0 KiB", BytesSize(1024))
+	assertEquals(t, "1.0 MiB", BytesSize(1024*1024))
+	assertEquals(t, "1.0 MiB", BytesSize(1048576))
+	assertEquals(t, "2.0 MiB", BytesSize(2*MiB))
+	assertEquals(t, "3.4 GiB", BytesSize(3.42*GiB))
+	assertEquals(t, "5.4 TiB", BytesSize(5.372*TiB))
+	assertEquals(t, "2.2 PiB", BytesSize(2.22*PiB))
+	assertEquals(t, "1.0e+06 YiB", BytesSize(KiB*KiB*KiB*KiB*KiB*PiB))
 }
 
 func TestHumanSize(t *testing.T) {
-	assertEquals(t, "1 kB", HumanSize(1000))
-	assertEquals(t, "1.024 kB", HumanSize(1024))
-	assertEquals(t, "1 MB", HumanSize(1000000))
-	assertEquals(t, "1.049 MB", HumanSize(1048576))
-	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(float64(3.42*GB)))
-	assertEquals(t, "5.372 TB", HumanSize(float64(5.372*TB)))
-	assertEquals(t, "2.22 PB", HumanSize(float64(2.22*PB)))
-	assertEquals(t, "1e+04 YB", HumanSize(float64(10000000000000*PB)))
+	assertEquals(t, "1.0 kB", HumanSize(1000))
+	assertEquals(t, "1.0 kB", HumanSize(1024))
+	assertEquals(t, "1.0 MB", HumanSize(1000000))
+	assertEquals(t, "1.0 MB", HumanSize(1048576))
+	assertEquals(t, "2.0 MB", HumanSize(2*MB))
+	assertEquals(t, "3.4 GB", HumanSize(float64(3.42*GB)))
+	assertEquals(t, "5.4 TB", HumanSize(float64(5.372*TB)))
+	assertEquals(t, "2.2 PB", HumanSize(float64(2.22*PB)))
+	assertEquals(t, "1.0e+04 YB", HumanSize(float64(10000000000000*PB)))
 }
 
 func TestFromHumanSize(t *testing.T) {


### PR DESCRIPTION
Closes #9 
```
Set a consistent precision to avert confusion as described here:
https://github.com/docker/docker/issues/9977

In addition, align the output as suggested here:
https://github.com/docker/go-units/issues/9
```

@thaJeztah @janten @calavera @LK4D4, feedback :thought_balloon: , please?

Thanks.