### PR TITLE
Add `HumanSizeWithPrecision` function

### DIFF
--- a/size.go
+++ b/size.go
@@ -37,22 +37,34 @@ var (
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 
-// CustomSize returns a human-readable approximation of a size
-// using custom format.
-func CustomSize(format string, size float64, base float64, _map []string) string {
+func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
 	i := 0
 	unitsLimit := len(_map) - 1
 	for size >= base && i < unitsLimit {
 		size = size / base
 		i++
 	}
-	return fmt.Sprintf(format, size, _map[i])
+	return size, _map[i]
+}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	size, unit := getSizeAndUnit(size, base, _map)
+	return fmt.Sprintf(format, size, unit)
+}
+
+// HumanSizeWithPrecision allows the size to be in any precision,
+// instead of 4 digit precision used in units.HumanSize.
+func HumanSizeWithPrecision(size float64, precision int) string {
+	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
+	return fmt.Sprintf("%.*g %s", precision, size, unit)
 }
 
 // HumanSize returns a human-readable approximation of a size
 // capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
 func HumanSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
+	return HumanSizeWithPrecision(size, 4)
 }
 
 // BytesSize returns a human-readable size in bytes, kibibytes,


### PR DESCRIPTION
This fix adds `HumanSizeWithPrecision` func so that instead of fixed
precision of 4 in `HumanSize`, any precision could be specified.

This fix is related to:
https://github.com/docker/docker/pull/26303
https://github.com/docker/docker/issues/26300
in docker.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>