### PR TITLE
Removes spaces before unit.

### DIFF
--- a/size.go
+++ b/size.go
@@ -58,7 +58,7 @@ func CustomSize(format string, size float64, base float64, _map []string) string
 // instead of 4 digit precision used in units.HumanSize.
 func HumanSizeWithPrecision(size float64, precision int) string {
 	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
-	return fmt.Sprintf("%.*g %s", precision, size, unit)
+	return fmt.Sprintf("%.*g%s", precision, size, unit)
 }
 
 // HumanSize returns a human-readable approximation of a size
@@ -70,7 +70,7 @@ func HumanSize(size float64) string {
 // BytesSize returns a human-readable size in bytes, kibibytes,
 // mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
 func BytesSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1024.0, binaryAbbrs)
+	return CustomSize("%.4g%s", size, 1024.0, binaryAbbrs)
 }
 
 // FromHumanSize returns an integer from a human-readable specification of a

--- a/size_test.go
+++ b/size_test.go
@@ -60,26 +60,26 @@ func ExampleRAMInBytes() {
 }
 
 func TestBytesSize(t *testing.T) {
-	assertEquals(t, "1 KiB", BytesSize(1024))
-	assertEquals(t, "1 MiB", BytesSize(1024*1024))
-	assertEquals(t, "1 MiB", BytesSize(1048576))
-	assertEquals(t, "2 MiB", BytesSize(2*MiB))
-	assertEquals(t, "3.42 GiB", BytesSize(3.42*GiB))
-	assertEquals(t, "5.372 TiB", BytesSize(5.372*TiB))
-	assertEquals(t, "2.22 PiB", BytesSize(2.22*PiB))
-	assertEquals(t, "1.049e+06 YiB", BytesSize(KiB*KiB*KiB*KiB*KiB*PiB))
+	assertEquals(t, "1KiB", BytesSize(1024))
+	assertEquals(t, "1MiB", BytesSize(1024*1024))
+	assertEquals(t, "1MiB", BytesSize(1048576))
+	assertEquals(t, "2MiB", BytesSize(2*MiB))
+	assertEquals(t, "3.42GiB", BytesSize(3.42*GiB))
+	assertEquals(t, "5.372TiB", BytesSize(5.372*TiB))
+	assertEquals(t, "2.22PiB", BytesSize(2.22*PiB))
+	assertEquals(t, "1.049e+06YiB", BytesSize(KiB*KiB*KiB*KiB*KiB*PiB))
 }
 
 func TestHumanSize(t *testing.T) {
-	assertEquals(t, "1 kB", HumanSize(1000))
-	assertEquals(t, "1.024 kB", HumanSize(1024))
-	assertEquals(t, "1 MB", HumanSize(1000000))
-	assertEquals(t, "1.049 MB", HumanSize(1048576))
-	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(float64(3.42*GB)))
-	assertEquals(t, "5.372 TB", HumanSize(float64(5.372*TB)))
-	assertEquals(t, "2.22 PB", HumanSize(float64(2.22*PB)))
-	assertEquals(t, "1e+04 YB", HumanSize(float64(10000000000000*PB)))
+	assertEquals(t, "1kB", HumanSize(1000))
+	assertEquals(t, "1.024kB", HumanSize(1024))
+	assertEquals(t, "1MB", HumanSize(1000000))
+	assertEquals(t, "1.049MB", HumanSize(1048576))
+	assertEquals(t, "2MB", HumanSize(2*MB))
+	assertEquals(t, "3.42GB", HumanSize(float64(3.42*GB)))
+	assertEquals(t, "5.372TB", HumanSize(float64(5.372*TB)))
+	assertEquals(t, "2.22PB", HumanSize(float64(2.22*PB)))
+	assertEquals(t, "1e+04YB", HumanSize(float64(10000000000000*PB)))
 }
 
 func TestFromHumanSize(t *testing.T) {


### PR DESCRIPTION
This is to be closer to common Linux outputs.
See https://github.com/docker/docker/issues/30271