### PR TITLE
Fix #26 - RAMInBytes Bug

### DIFF
--- a/size.go
+++ b/size.go
@@ -31,7 +31,7 @@ type unitMap map[string]int64
 var (
 	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
 	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
-	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[iI]?[bB]?$`)
 )
 
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}

--- a/size_test.go
+++ b/size_test.go
@@ -116,6 +116,8 @@ func TestRAMInBytes(t *testing.T) {
 	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32K")
 	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32kb")
 	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32Kb")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32Kib")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32KIB")
 	assertSuccessEquals(t, 32*MiB, RAMInBytes, "32Mb")
 	assertSuccessEquals(t, 32*GiB, RAMInBytes, "32Gb")
 	assertSuccessEquals(t, 32*TiB, RAMInBytes, "32Tb")


### PR DESCRIPTION
RAMInBytes wasn't able to parse the output of BytesSize until now.

Signed-off-by: Florin Asavoaie <FlorinAsavoaie@users.noreply.github.com>