### PR TITLE
Update path of golint

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   post:
     # install golint
-    - go get github.com/golang/lint/golint
+    - go get golang.org/x/lint/golint
 
 test:
   pre:


### PR DESCRIPTION
The new path is golang.org/x/lint/golint.
See https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3.

Signed-off-by: Julien Barbot <jubarbot@cisco.com>