### PR TITLE
MAINTAINERS: update Akihiro Suda's email address

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -27,7 +27,7 @@
 
 	[people.akihirosuda]
 	Name = "Akihiro Suda"
-	Email = "suda.akihiro@lab.ntt.co.jp"
+	Email = "akihiro.suda.cz@hco.ntt.co.jp"
 	GitHub = "AkihiroSuda"
 
 	[people.dnephin]


### PR DESCRIPTION
No affiliation change (NTT).

The former email address will continue to be available for the time being.

For daily communication, I still prefer to use my gmail.com address.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>