### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/docker/go-units
+
+go 1.20


### PR DESCRIPTION
Keeping the go version to 1.20 for now, as this module doesn't require "latest and greatest"
