### PR TITLE
[feat] support "infinity" in ulimit values, as an alias to `-1`

### DIFF
--- a/ulimit.go
+++ b/ulimit.go
@@ -62,6 +62,13 @@ var ulimitNameMapping = map[string]int{
 	"stack":      rlimitStack,
 }
 
+func parseUlimitValue(s string) (int64, error) {
+	if s == "infinity" {
+		return -1, nil
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
 // ParseUlimit parses and returns a Ulimit from the specified string.
 func ParseUlimit(val string) (*Ulimit, error) {
 	parts := strings.SplitN(val, "=", 2)
@@ -81,14 +88,14 @@ func ParseUlimit(val string) (*Ulimit, error) {
 	)
 	switch limitVals := strings.Split(parts[1], ":"); len(limitVals) {
 	case 2:
-		temp, err = strconv.ParseInt(limitVals[1], 10, 64)
+		temp, err = parseUlimitValue(limitVals[1])
 		if err != nil {
 			return nil, err
 		}
 		hard = &temp
 		fallthrough
 	case 1:
-		soft, err = strconv.ParseInt(limitVals[0], 10, 64)
+		soft, err = parseUlimitValue(limitVals[0])
 		if err != nil {
 			return nil, err
 		}

--- a/ulimit_test.go
+++ b/ulimit_test.go
@@ -56,6 +56,13 @@ func TestParseUlimitHardLessThanSoft(t *testing.T) {
 	}
 }
 
+func TestParseUlimitInfinity(t *testing.T) {
+	u1 := &Ulimit{"memlock", -1, -1}
+	if u2, _ := ParseUlimit("memlock=infinity:infinity"); *u1 != *u2 {
+		t.Fatalf("expected %q, but got %q", u1, u2)
+	}
+}
+
 func TestParseUlimitUnlimited(t *testing.T) {
 	tt := []struct {
 		in       string


### PR DESCRIPTION
Hello, team!

I'd like to use `--ulimit memlock=infinity`, as `sys/resource.h` provides `RLIM_INFINITY`.  Fortunately, `-1` is already supported as the infinity, so I've implemented a new keyword `infinity` as an alias to `-1`.

* [x] unit tests