### PR TITLE
add EB and EiB to size

### DIFF
--- a/size.go
+++ b/size.go
@@ -15,6 +15,7 @@ const (
 	GB = 1000 * MB
 	TB = 1000 * GB
 	PB = 1000 * TB
+	EB = 1000 * PB
 
 	// Binary
 
@@ -23,13 +24,14 @@ const (
 	GiB = 1024 * MiB
 	TiB = 1024 * GiB
 	PiB = 1024 * TiB
+	EiB = 1024 * PiB
 )
 
 type unitMap map[byte]int64
 
 var (
-	decimalMap = unitMap{'k': KB, 'm': MB, 'g': GB, 't': TB, 'p': PB}
-	binaryMap  = unitMap{'k': KiB, 'm': MiB, 'g': GiB, 't': TiB, 'p': PiB}
+	decimalMap = unitMap{'k': KB, 'm': MB, 'g': GB, 't': TB, 'p': PB, 'e': EB}
+	binaryMap  = unitMap{'k': KiB, 'm': MiB, 'g': GiB, 't': TiB, 'p': PiB, 'e': EiB}
 )
 
 var (


### PR DESCRIPTION
Allow to parse units EB and EiB. I do not add ZB and YB because they are larger than int64 range