### PR TITLE
Update Go docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/docker/go-units?status.svg)](https://godoc.org/github.com/docker/go-units)
+[![Go Reference](https://pkg.go.dev/badge/github.com/docker/go-units.svg)](https://pkg.go.dev/github.com/docker/go-units)
 
 # Introduction
 
@@ -6,7 +6,7 @@ go-units is a library to transform human friendly measurements into machine frie
 
 ## Usage
 
-See the [docs in godoc](https://godoc.org/github.com/docker/go-units) for examples and documentation.
+See the [docs](https://pkg.go.dev/github.com/docker/go-units) for examples and documentation.
 
 ## Copyright and license
 


### PR DESCRIPTION
This PR replaces the deprecated `GoDoc` links with new ones to `Go Reference` in `README.md`.

See golang/go#49212 for details about the deprecated `godoc`.

The badge is created at https://pkg.go.dev/badge/.